### PR TITLE
RND 4300: update jsmin with upstream

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v3.0.0 (2021-09-08) Ben Bradshaw
+--------------------------------
+
+- Breaking Change: Removed support for Python 2
+
+- Removed usage of use_2to3 in setup.py
+
 v2.2.2 (2017-05-01) Tikitu de Jager
 -----------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,12 @@ Where to get it
 * get the latest release `from latest-release on github <https://github.com/tikitu/jsmin/tree/latest-release/jsmin>`_
 * get the development version `from master on github <https://github.com/tikitu/jsmin/>`_
 
+
+Python 2 support removed
+========================
+
+Python 2 support was removed in version 3.0.0. If you need to support Python 2, please use version 2.2.2 with setuptools<58.
+
 Contributing
 ============
 
@@ -60,7 +66,7 @@ Build/test status
 
 Both branches are tested with Travis: https://travis-ci.org/tikitu/jsmin
 
-The `latest-release` branch (the version on PyPI plus any new tests) is tested against CPython 2.6, 2.7, 3.2, and 3.3.
+The `latest-release` branch (the version on PyPI plus any new tests) is tested against CPython 3.
 Currently:
 
 .. image:: https://travis-ci.org/tikitu/jsmin.png?branch=latest-release
@@ -68,8 +74,8 @@ Currently:
 If that branch is failing that means there's a new test that fails on *the latest released version on pypi*, with no fix yet
 released.
 
-The `master` branch (development version, might be ahead of latest released version) is tested against CPython 2.6, 2.7, 3.2, and
-3.3. Currently:
+The `master` branch (development version, might be ahead of latest released version) is tested against CPython 3.
+Currently:
 
 .. image:: https://travis-ci.org/tikitu/jsmin.png?branch=master
 
@@ -86,3 +92,4 @@ Contributors (chronological commit order)
 * `Gennady Kovshenin <https://github.com/soulseekah>`_
 * `Matt Molyneaux <https://github.com/moggers87>`_
 * `Albert Wang <https://github.com/albertyw>`_
+* `Ben Bradshaw <https://github.com/serenecloud>`_

--- a/jsmin/__init__.py
+++ b/jsmin/__init__.py
@@ -26,35 +26,17 @@
 # THE SOFTWARE.
 
 
-import sys
-is_3 = sys.version_info >= (3, 0)
-if is_3:
-    import io
-else:
-    import StringIO
-    try:
-        import cStringIO
-    except ImportError:
-        cStringIO = None
-
+import io
 
 __all__ = ['jsmin', 'JavascriptMinify']
-__version__ = '2.2.3.dev'
+__version__ = '3.0.1'
 
 
 def jsmin(js, **kwargs):
     """
     returns a minified version of the javascript string
     """
-    if not is_3:        
-        if cStringIO and not isinstance(js, unicode):
-            # strings can use cStringIO for a 3x performance
-            # improvement, but unicode (in python2) cannot
-            klass = cStringIO.StringIO
-        else:
-            klass = StringIO.StringIO
-    else:
-        klass = io.StringIO
+    klass = io.StringIO
     ins = klass(js)
     outs = klass()
     JavascriptMinify(ins, outs, **kwargs).minify()

--- a/jsmin/test.py
+++ b/jsmin/test.py
@@ -592,15 +592,7 @@ console.log('hello!');}/*! Copyright blah blah
 class RegexTests(unittest.TestCase):
 
     def regex_recognise(self, js):
-        if not jsmin.is_3:
-            if jsmin.cStringIO and not isinstance(js, unicode):
-                # strings can use cStringIO for a 3x performance
-                # improvement, but unicode (in python2) cannot
-                klass = jsmin.cStringIO.StringIO
-            else:
-                klass = jsmin.StringIO.StringIO
-        else:
-            klass = jsmin.io.StringIO
+        klass = jsmin.io.StringIO
         ins = klass(js[2:])
         outs = klass()
         jsmin.JavascriptMinify(ins, outs).regex_literal(js[0], js[1])

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,6 @@ import os, sys, re
 os.environ['COPYFILE_DISABLE'] = 'true'  # this disables including resource forks in tar files on os x
 
 
-extra = {}
-if sys.version_info >= (3,0):
-    extra['use_2to3'] = True
-
-
 def long_description():
     return open('README.rst').read() + '\n' + open('CHANGELOG.txt').read()
 
@@ -33,15 +28,9 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Pre-processors',
         'Topic :: Text Processing :: Filters',
-    ],
-    **extra
+    ]
 )


### PR DESCRIPTION
Currently, with newer versions of pip, 2to3 is removed, in order to install our local fork of jsmin, I pulled in the recent changes with jsmin upstream which remove python2 support. WIthout this change, any of our repos with jsmin as a dependency will not build on newer versions of pip